### PR TITLE
Include "HUB" in namePrefix filter

### DIFF
--- a/lib/poweredup.js
+++ b/lib/poweredup.js
@@ -17,7 +17,8 @@
 				try {
 		            let device = await navigator.bluetooth.requestDevice({
 				        filters: [
-				        	{ namePrefix: 'Smart Hub' }
+				        	{ namePrefix: 'Smart Hub' },
+						{ namePrefix: 'HUB' }
 				        ],
 				        optionalServices: [
 					        '00001623-1212-efde-1623-785feabcd123'


### PR DESCRIPTION
My PoweredUp hub has the name "HUB no.4" rather than starting with "Smart Hub." Include this in the scan filter.