### PR TITLE
Monkey-patch `BluetoothRemoteGATTCharacteristic.writeValue()` values

### DIFF
--- a/lib/poweredup.js
+++ b/lib/poweredup.js
@@ -1,100 +1,159 @@
 (function() {
-	'use strict';
-	
-	class PoweredUp {
-		constructor() {
-			this._EVENTS = {};
-			this._PROMISES = {};
-			
-            this._CHARACTERISTIC = null;
+  'use strict';
 
-			this._QUEUE = [];
-			this._WORKING = false;
-		}
-		
-		connect() {
-            return new Promise(async (resolve, reject) => {
-				try {
-		            let device = await navigator.bluetooth.requestDevice({
-				        filters: [
-				        	{ namePrefix: 'Smart Hub' },
-						{ namePrefix: 'HUB' }
-				        ],
-				        optionalServices: [
-					        '00001623-1212-efde-1623-785feabcd123'
-					    ]
-					});
-					
-					device.addEventListener('gattserverdisconnected', this._disconnect.bind(this));
-					
-					let server = await device.gatt.connect();
-					let service = await server.getPrimaryService('00001623-1212-efde-1623-785feabcd123');
+  class PoweredUp {
+    constructor() {
+      this._EVENTS = {};
+      this._PROMISES = {};
 
-					this._CHARACTERISTIC = await service.getCharacteristic('00001624-1212-efde-1623-785feabcd123');
-					this._CHARACTERISTIC.startNotifications();
-					this._CHARACTERISTIC.addEventListener('characteristicvaluechanged', function(e) { 
-                        // received...
-					}.bind(this));	
-		            
+      this._CHARACTERISTIC = null;
 
-		            resolve();
-		        }
-				catch(error) {
-	                console.log('Could not connect! ' + error);
-					reject();
-				}
-			});
+      this._QUEUE = [];
+      this._LED_QUEUE = [];
+      this._WORKING = false;
+    }
+
+    connect() {
+      return new Promise(async (resolve, reject) => {
+        try {
+          let device = await navigator.bluetooth.requestDevice({
+            filters: [{
+              namePrefix: 'HUB'
+            }],
+            optionalServices: [
+              '00001623-1212-efde-1623-785feabcd123'
+            ]
+          });
+
+          device.addEventListener('gattserverdisconnected', this._disconnect.bind(this));
+
+          let server = await device.gatt.connect();
+          let service = await server.getPrimaryService('00001623-1212-efde-1623-785feabcd123');
+          console.log(service)
+
+          this._CHARACTERISTIC = await service.getCharacteristic('00001624-1212-efde-1623-785feabcd123');
+          window.c = this._CHARACTERISTIC;
+          this._CHARACTERISTIC.startNotifications();
+          this._CHARACTERISTIC.addEventListener('characteristicvaluechanged', function(e) {
+            // received...
+          }.bind(this));
+
+
+          resolve();
+        } catch (error) {
+          console.log('Could not connect! ' + error);
+          reject();
+        }
+      });
+    }
+
+    drive(left, right) {
+      // Forward
+      if (left === 126 && right === -126) {
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x32, 0x11, 0x51, 0x00, 1
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x00, 0x11, 0x51, 0x00, left
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x01, 0x11, 0x51, 0x00, right
+          ]));
+        // Backward
+      } else if (left === -126 && right === 126) {
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x32, 0x11, 0x51, 0x00, 2
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x00, 0x11, 0x51, 0x00, left
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x01, 0x11, 0x51, 0x00, right
+          ]));
+        // Left
+      } else if (left === 126 && (right === 126 || right === -30)) {
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x32, 0x11, 0x51, 0x00, 3
+          ]));
+
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x00, 0x11, 0x51, 0x00, left
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x01, 0x11, 0x51, 0x00, right
+          ]));
+        // Right
+      } else if ((left === -126 || left === 30) && right === -126) {
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x32, 0x11, 0x51, 0x00, 4
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x00, 0x11, 0x51, 0x00, left
+          ]));
+        this._queue(
+          new Uint8Array([
+            0x08, 0x00, 0x81, 0x01, 0x11, 0x51, 0x00, right
+          ]));
+      }
+    }
+
+    stop() {
+      this._queue(new Uint8Array([
+        0x08, 0x00, 0x81, 0x00, 0x11, 0x51, 0x00, 0x00
+      ]));
+      this._queue(new Uint8Array([
+        0x08, 0x00, 0x81, 0x01, 0x11, 0x51, 0x00, 0x00
+      ]));
+    }
+
+    addEventListener(e, f) {
+      this._EVENTS[e] = f;
+    }
+
+    isConnected() {
+      return !!this._CHARACTERISTIC;
+    }
+
+    _disconnect() {
+      console.log('Disconnected from GATT Server...');
+
+      this._CHARACTERISTIC = null;
+
+      if (this._EVENTS['disconnected']) {
+        this._EVENTS['disconnected']();
+      }
+    }
+
+    _queue(message) {
+      var that = this;
+
+      function run() {
+        if (!that._QUEUE.length) {
+          that._WORKING = false;
+          return;
         }
 
-        drive(left, right) {
-            this._queue(new Uint8Array([
-                0x08, 0x00, 0x81, 0x39, 0x11, 0x02, left, right
-            ]));
-        }
+        that._WORKING = true;
 
-        stop() {
-            this._queue(new Uint8Array([
-                0x08, 0x00, 0x81, 0x39, 0x11, 0x02, 0x00, 0x00
-            ]));
-        }
+        that._CHARACTERISTIC.writeValue(that._QUEUE.shift()).then(() => run());
+      }
 
-		addEventListener(e, f) {
-			this._EVENTS[e] = f;
-		}
+      that._QUEUE.push(message);
 
-		isConnected() {
-			return !!this._CHARACTERISTIC;
-		}
-			
-		_disconnect() {
-            console.log('Disconnected from GATT Server...');
+      if (!that._WORKING) run();
+    }
+  }
 
-			this._CHARACTERISTIC = null;
-			
-			if (this._EVENTS['disconnected']) {
-				this._EVENTS['disconnected']();
-			}
-		}
-		
-		_queue(message) {
-			var that = this;
-			
-			function run() {
-				if (!that._QUEUE.length) {
-					that._WORKING = false; 
-					return;
-				}
-				
-                that._WORKING = true;
-                that._CHARACTERISTIC.writeValue(that._QUEUE.shift()).then(() => run() );
-			}
-
-            that._QUEUE.push(message);
-			
-			if (!that._WORKING) run();	
-        }
-	}
-
-    window.PoweredUp = new PoweredUp();
+  window.PoweredUp = new PoweredUp();
 })();
-


### PR DESCRIPTION
Hi @NielsLeenheer,

We want to use the Batmobile demo for Google I/O. Unfortunately it seems like there were some changes on LEGO's end, this PR fixes those. I also changed the indentation that was a mix of tabs and spaces, sorry for the noise.

Essentially what the PR does is that it sends the (new?) corrected `BluetoothRemoteGATTCharacteristic.writeValue()` values in two separate writes to the two motors. I couldn't find a way to bundle both into one. This is probably not the best way to do it, but it works for now.

I've also added a fun new feature that dependent on the direction makes the LED light up in a different color. You can find the fixed version at https://batmobile.glitch.me/. 

Cheers,
Tom

--
PS: I noticed that https://bluetooth.rocks/batmobile/ doesn't include @reillyeon's [fix](https://github.com/BluetoothRocks/Batmobile/pull/1) yet, so before noticing that the commands had changed, I banged my head against my desk for a while attempting to pair until I realized the problem.